### PR TITLE
Parse strings in grunt commands.

### DIFF
--- a/syntax/pig.vim
+++ b/syntax/pig.vim
@@ -47,7 +47,7 @@ syn match pigAssignEq  "=" contained
 
 syn match pigSpecial "[#*]"
 
-syn match pigGrunt "^\s*\(cat\|cd\|cp\|copyFromLocal\|copyToLocal\|define\|dump\|illustrate\|describe\|explain\|help\|kill\|ls\|mv\|mkdir\|pwd\|quit\|import\|register\|rm\|rmf\|set\)\>.*$" contains=pigGruntCmd,pigRegisterKeyword,pigComment
+syn match pigGrunt "^\s*\(cat\|cd\|cp\|copyFromLocal\|copyToLocal\|define\|dump\|illustrate\|describe\|explain\|help\|kill\|ls\|mv\|mkdir\|pwd\|quit\|import\|register\|rm\|rmf\|set\)\>.*$" contains=pigGruntCmd,pigRegisterKeyword,pigString,pigComment
 syn match pigGruntCmd "^\s*\(cat\|cd\|cp\|copyFromLocal\|copyToLocal\|define\|dump\|illustrate\|describe\|explain\|help\|kill\|ls\|mv\|mkdir\|pwd\|quit\|rm\|rmf\|set\)\>" contained
 syn match pigRegisterKeyword "^\s*\(register\|import\)\>" contained
 


### PR DESCRIPTION
Commands matched by `pigGrunt` may contain string literals, which are currently not matched. This causes an issue if the strings contain comment markers.

For example, I have a script that starts with `register 'lib/*.jar'`, all subsequent lines are highlighted as comments.
